### PR TITLE
다크모드 사용 시에도 아이콘 보이도록 수정

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/styles/style_widget.dart
+++ b/lib/styles/style_widget.dart
@@ -476,17 +476,15 @@ class _InfoCardState extends State<InfoCard> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               ListTile(
-                title: Text(
-                  widget.title,
-                  semanticsLabel: widget.title,
-                  style: const TextStyle(
-                      fontWeight: FontWeight.bold, fontSize: 18.0),
-                ),
-                leading: Icon(
-                  widget.icon,
-                  color: Theme.of(context).primaryColor,
-                ),
-              ),
+                  title: Text(
+                    widget.title,
+                    semanticsLabel: widget.title,
+                    style: const TextStyle(
+                        fontWeight: FontWeight.bold, fontSize: 18.0),
+                  ),
+                  leading: Icon(
+                    widget.icon,
+                  )),
               widget.detail
             ],
           ),


### PR DESCRIPTION
## 해결한 이슈

> `fix #[ISSUME_NUMBER] 목록 형식으로 작성`

- fix #19

## 주요 변경사항

- `style_widget` 내 `InfoCard` 아이콘 색상 지정 제거

## 참고사항

- 